### PR TITLE
reduce sleeping beggar health and fix wrong objective visibility after reading briefing

### DIFF
--- a/maps/fsx.darkradiant
+++ b/maps/fsx.darkradiant
@@ -2,14 +2,14 @@ DarkRadiant Map Information File Version 2
 {
 	MapProperties
 	{
-		KeyValue { "EditTimeInSeconds" "2967230" } 
-		KeyValue { "LastCameraAngle" "-23.1 180.6 0" } 
+		KeyValue { "EditTimeInSeconds" "2967323" } 
+		KeyValue { "LastCameraAngle" "-20.7 186.6 0" } 
 		KeyValue { "LastCameraPosition" "494.586 3373.32 91.8766" } 
 		KeyValue { "LastShaderClipboardMaterial" "textures/common/monster_clip" } 
 	}
 	MapEditTimings
 	{
-		TotalSecondsEdited { 2967230 }
+		TotalSecondsEdited { 2967323 }
 	}
 	Layers
 	{


### PR DESCRIPTION
fixes #390

This is a dummy PR - the changes have nothing to do with the fix in the title, those changes were done in a previous commit that was accidentally pushed directly to the main branch.  This is just to get the change to show up in the automated release notes.