### PR TITLE
teleport safe house items instead of spawning

### DIFF
--- a/maps/fsx.darkradiant
+++ b/maps/fsx.darkradiant
@@ -2,14 +2,14 @@ DarkRadiant Map Information File Version 2
 {
 	MapProperties
 	{
-		KeyValue { "EditTimeInSeconds" "2982922" } 
-		KeyValue { "LastCameraAngle" "3.9 55.8 0" } 
-		KeyValue { "LastCameraPosition" "-820.064 4057.93 255.206" } 
+		KeyValue { "EditTimeInSeconds" "2983545" } 
+		KeyValue { "LastCameraAngle" "-36.6 101.7 0" } 
+		KeyValue { "LastCameraPosition" "346.061 2202 313.928" } 
 		KeyValue { "LastShaderClipboardMaterial" "textures/darkmod/window/fs_smallpanels_4w_dirty01_unlit" } 
 	}
 	MapEditTimings
 	{
-		TotalSecondsEdited { 2982922 }
+		TotalSecondsEdited { 2983545 }
 	}
 	SelectionGroups
 	{
@@ -76349,6 +76349,13 @@ DarkRadiant Map Information File Version 2
 		Node { 10 } // entity (func_static_4914)
 		Node { 10 } // brush (Brush)
 		Node { 10 } // patch (Patch)
+		Node { 4 } // entity (fsx_prison_cell_key_1)
+		Node { 4 } // entity (teleport_prison_key)
+		Node { 4 } // entity (fsx_safe_house_letter_1)
+		Node { 4 } // entity (trigger_safe_house)
+		Node { 4 } // entity (teleport_safe_house_letter)
+		Node { 4 } // entity (teleport_newspaper)
+		Node { 4 } // entity (fsx_newspaper_1)
 	}
 	SelectionSets
 	{

--- a/maps/fsx.script
+++ b/maps/fsx.script
@@ -32,9 +32,13 @@ string POPUP_ELLA_BROACH = "popup_ella_broach";
 string TRIGGER_ATKINSON_OBJECTIVE = "trigger_relay_atkinson_objective";
 string TRIGGER_COUNT_FIREARROW = "trigger_count_firearrow";
 
+// Coates teleport triggers
 string TRIGGER_COATES_CHURCH = "trigger_coates_church";
 string TRIGGER_COATES_HOTEL = "trigger_coates_hotel";
 string TRIGGER_COATES_MANSION = "trigger_coates_mansion";
+
+// Triggered when Coates is killed
+string TRIGGER_SAFE_HOUSE = "trigger_safe_house";
 
 // Locations
 string LOCATION_ABBEY_LOFT = "location_abbey_loft";
@@ -163,15 +167,8 @@ void triggerSafeHouseObjective()
         // set the safe house objective visible
         $player1.setObjectiveVisible(OBJ_SAFE_HOUSE, 1);
 
-        // Spawn prison cell key at Lennard's
-        spawnEntity("335.972 2295.93 223.278", "0.592432 0.80562 0 -0.80562 0.592432 0 0 0 1", "fsx:prison_cell_key");
-
-        // Spawn the letter
-        spawnEntity("320 2294 222.881", "1 0 0 0 1 0 0 0 1", "fsx:safe_house_letter");
-
-        // Spawn the newspaper. We prefer if the player finds this in the Review Office, but
-        // in case they never find it they can read it here after Coates is killed.
-        spawnEntity("363.295 2236.69 21.3811", "0.759739 0.650229 0 -0.650229 0.759739 0 0 0 1", "fsx:newspaper");
+        // Trigger teleport of prison key, safe house letter and newspaper into the safe house
+        sys.trigger(sys.getEntity(TRIGGER_SAFE_HOUSE));
     }
     else
     {


### PR DESCRIPTION
Teleport the safe house letter, prison key and newspaper instead of using sys.spawn().  Spawning has been unreliable on multiple occasions. Fixes #477 