### PR TITLE
remove 'player responsible' flag from Coates objective due to issue 6323

### DIFF
--- a/maps/fsx.darkradiant
+++ b/maps/fsx.darkradiant
@@ -2,7 +2,7 @@ DarkRadiant Map Information File Version 2
 {
 	MapProperties
 	{
-		KeyValue { "EditTimeInSeconds" "2983981" } 
+		KeyValue { "EditTimeInSeconds" "2984005" } 
 		KeyValue { "LastCameraAngle" "-20.2 174.1 0" } 
 		KeyValue { "LastCameraPosition" "442.713 3080.24 22.2727" } 
 		KeyValue { "LastShaderClipboardMaterial" "textures/darkmod/window/fs_smallpanels_4w_dirty01_unlit" } 
@@ -12,7 +12,7 @@ DarkRadiant Map Information File Version 2
 	}
 	MapEditTimings
 	{
-		TotalSecondsEdited { 2983981 }
+		TotalSecondsEdited { 2984005 }
 	}
 	SelectionGroups
 	{


### PR DESCRIPTION
fixes #485 

Caused by TDM bug https://bugs.thedarkmod.com/view.php?id=6323